### PR TITLE
PropertyInjectionBuilderStrategy executed for child and parent container

### DIFF
--- a/src/NServiceBus.Unity.Tests/App_Packages/NSB.ContainerTests.5.1.2/When_releasing_components.cs
+++ b/src/NServiceBus.Unity.Tests/App_Packages/NSB.ContainerTests.5.1.2/When_releasing_components.cs
@@ -10,25 +10,26 @@ namespace NServiceBus.ContainerTests
         [Test]
         public void Transient_component_should_be_destructed_called()
         {
-            using (var builder = TestContainerBuilder.ConstructBuilder())
-            {
-                builder.Configure(typeof(TransientClass), DependencyLifecycle.InstancePerCall);
+            var builder = TestContainerBuilder.ConstructBuilder();
 
-                var comp = (TransientClass) builder.Build(typeof(TransientClass));
-                comp.Name = "Jon";
+            builder.Configure(typeof(TransientClass), DependencyLifecycle.InstancePerCall);
 
-                var weak = new WeakReference(comp);
+            var comp = (TransientClass)builder.Build(typeof(TransientClass));
+            comp.Name = "Jon";
 
-                builder.Release(comp);
-                // ReSharper disable once RedundantAssignment
-                comp = null;
+            var weak = new WeakReference(comp);
 
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
+            builder.Release(comp);
+            // ReSharper disable once RedundantAssignment
+            comp = null;
 
-                Assert.IsFalse(weak.IsAlive);
-                Assert.IsTrue(TransientClass.Destructed);
-            }
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.IsFalse(weak.IsAlive);
+            Assert.IsTrue(TransientClass.Destructed);
+
+            builder.Dispose();
 
         }
 

--- a/src/NServiceBus.Unity.Tests/When_using_existing_container.cs
+++ b/src/NServiceBus.Unity.Tests/When_using_existing_container.cs
@@ -115,22 +115,6 @@
             Assert.IsNotNull(result.Dependency);
         }
 
-        [Test]
-        public void Existing_instances_registred_in_the_container_can_be_injected_via_property_only_once_set()
-        {
-            var container = new UnityContainer();
-
-            var builder = new UnityObjectBuilder(container);
-            builder.Configure(typeof(PropertyInjectionHandler), DependencyLifecycle.InstancePerUnitOfWork);
-            container.RegisterType<ISomeInterface, SomeClass>(new HierarchicalLifetimeManager());
-
-            var childBuilder = builder.BuildChildContainer();
-
-            var result = (PropertyInjectionHandler)childBuilder.Build(typeof(PropertyInjectionHandler));
-
-            Assert.IsNotNull(result.Dependency);
-        }
-
 
         [Test]
         public void Existing_instances_registred_in_the_container_can_be_injected_via_constructor()

--- a/src/NServiceBus.Unity/PropertyInjectionBuilderStrategy.cs
+++ b/src/NServiceBus.Unity/PropertyInjectionBuilderStrategy.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Unity
 {
     using Microsoft.Practices.ObjectBuilder2;
+    using Microsoft.Practices.Unity;
 
     class PropertyInjectionBuilderStrategy : BuilderStrategy
     {
@@ -11,11 +12,23 @@ namespace NServiceBus.Unity
             this.unityContainer = unityContainer;
         }
 
+        private IUnityContainer GetUnityFromBuildContext(IBuilderContext context)
+        {
+            var lifetime = context.Policies.Get<ILifetimePolicy>(NamedTypeBuildKey.Make<IUnityContainer>());
+            return lifetime.GetValue() as IUnityContainer;
+        }
+
+        private bool IsCorrectContext(IBuilderContext context)
+        {
+            var container = this.GetUnityFromBuildContext(context);
+            return this.unityContainer.IsCorrectContext(container);
+        }
+
         public override void PreBuildUp(IBuilderContext context)
         {
             var type = context.BuildKey.Type;
             var target = context.Existing;
-            if (!type.FullName.StartsWith("Microsoft.Practices"))
+            if (!type.FullName.StartsWith("Microsoft.Practices") && this.IsCorrectContext(context))
             {
                 unityContainer.SetProperties(target.GetType(), target);
             }

--- a/src/NServiceBus.Unity/PropertyInjectionBuilderStrategy.cs
+++ b/src/NServiceBus.Unity/PropertyInjectionBuilderStrategy.cs
@@ -18,19 +18,15 @@ namespace NServiceBus.Unity
             return lifetime.GetValue() as IUnityContainer;
         }
 
-        private bool IsCorrectContext(IBuilderContext context)
-        {
-            var container = this.GetUnityFromBuildContext(context);
-            return this.unityContainer.IsCorrectContext(container);
-        }
-
         public override void PreBuildUp(IBuilderContext context)
         {
             var type = context.BuildKey.Type;
             var target = context.Existing;
-            if (!type.FullName.StartsWith("Microsoft.Practices") && this.IsCorrectContext(context))
+            var container = this.GetUnityFromBuildContext(context);
+
+            if (!type.FullName.StartsWith("Microsoft.Practices"))
             {
-                unityContainer.SetProperties(target.GetType(), target);
+                unityContainer.SetProperties(target.GetType(), target, container);
             }
         }
     }

--- a/src/NServiceBus.Unity/UnityObjectBuilder.cs
+++ b/src/NServiceBus.Unity/UnityObjectBuilder.cs
@@ -80,6 +80,11 @@
             }
         }
 
+        internal bool IsCorrectContext(IUnityContainer unityContainer)
+        {
+            return object.ReferenceEquals(unityContainer, this.container);
+        }
+
         public void Configure(Type concreteComponent, DependencyLifecycle dependencyLifecycle)
         {
             if (HasComponent(concreteComponent))

--- a/src/NServiceBus.Unity/UnityObjectBuilder.cs
+++ b/src/NServiceBus.Unity/UnityObjectBuilder.cs
@@ -85,7 +85,7 @@
 
         internal bool IsCorrectContext(IUnityContainer unityContainer)
         {
-            return ReferenceEquals(unityContainer, this.container);
+            return this.container.Equals(unityContainer);
         }
 
         public void Configure(Type concreteComponent, DependencyLifecycle dependencyLifecycle)

--- a/src/NServiceBus.Unity/UnityObjectBuilder.cs
+++ b/src/NServiceBus.Unity/UnityObjectBuilder.cs
@@ -9,7 +9,9 @@
     class UnityObjectBuilder : IContainer
     {
         IUnityContainer container;
-        Dictionary<Type, Dictionary<string, object>> configuredProperties = new Dictionary<Type, Dictionary<string, object>>();
+
+        Dictionary<Type, Dictionary<string, object>> configuredProperties;
+
         DefaultInstances defaultInstances;
 
         public UnityObjectBuilder()
@@ -18,7 +20,7 @@
         }
 
         public UnityObjectBuilder(IUnityContainer container)
-            : this(container, new DefaultInstances())
+            : this(container, new DefaultInstances(), new Dictionary<Type, Dictionary<string, object>>())
         {
             container.AddExtension(new RegisteringNotificationContainerExtension(
                 (from, to, lifetime) => defaultInstances.Add(from), 
@@ -35,10 +37,11 @@
             }
         }
 
-        UnityObjectBuilder(IUnityContainer container, DefaultInstances defaultInstances)
+        UnityObjectBuilder(IUnityContainer container, DefaultInstances defaultInstances, Dictionary<Type, Dictionary<string, object>> configuredProperties)
         {
             this.container = container;
             this.defaultInstances = defaultInstances;
+            this.configuredProperties = configuredProperties;
 
             var propertyInjectionExtension = this.container.Configure<PropertyInjectionContainerExtension>();
             if (propertyInjectionExtension == null)
@@ -55,7 +58,7 @@
 
         public IContainer BuildChildContainer()
         {
-            return new UnityObjectBuilder(container.CreateChildContainer(), defaultInstances);
+            return new UnityObjectBuilder(container.CreateChildContainer(), defaultInstances, configuredProperties);
         }
 
         public object Build(Type typeToBuild)

--- a/src/NServiceBus.Unity/UnityObjectBuilder.cs
+++ b/src/NServiceBus.Unity/UnityObjectBuilder.cs
@@ -82,7 +82,7 @@
 
         internal bool IsCorrectContext(IUnityContainer unityContainer)
         {
-            return object.ReferenceEquals(unityContainer, this.container);
+            return ReferenceEquals(unityContainer, this.container);
         }
 
         public void Configure(Type concreteComponent, DependencyLifecycle dependencyLifecycle)


### PR DESCRIPTION
When child container does a resolve, the the build strategies of parent and child container are executed. Depending on the order and lifetime the property can contain the wrong injected instance. The second drawback is the performance.