### PR TITLE
Ignore injecting static properties

### DIFF
--- a/src/NServiceBus.Unity.Tests/App_Packages/NSB.ContainerTests.5.1.2/When_registering_components.cs
+++ b/src/NServiceBus.Unity.Tests/App_Packages/NSB.ContainerTests.5.1.2/When_registering_components.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.ContainerTests
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Dynamic;
     using System.Linq;
     using NServiceBus;
     using NUnit.Framework;
@@ -163,6 +164,19 @@ namespace NServiceBus.ContainerTests
                 Assert.NotNull(component.ConcreteDependency, "Concrete classed should be property injected");
                 Assert.NotNull(component.InterfaceDependency, "Interfaces should be property injected");
                 Assert.NotNull(component.concreteDependencyWithSetOnly, "Set only properties should be supported");
+            }
+        } 
+        
+        [Test]
+        public void Static_setter_dependencies_should_not_be_supported()
+        {
+            using (var builder = TestContainerBuilder.ConstructBuilder())
+            {
+                builder.Configure(typeof(SomeClass), DependencyLifecycle.InstancePerCall);
+                builder.Configure(typeof(ClassWithAStaticPropertyMatchingDependency), DependencyLifecycle.SingleInstance);
+
+                var component = (ClassWithAStaticPropertyMatchingDependency)builder.Build(typeof(ClassWithAStaticPropertyMatchingDependency));
+                Assert.Null(ClassWithAStaticPropertyMatchingDependency.StaticProperty);
             }
         }
 
@@ -359,6 +373,11 @@ namespace NServiceBus.ContainerTests
 
     public interface IWithSetterDependencies
     {
+    }
+
+    public class ClassWithAStaticPropertyMatchingDependency
+    {
+        public static ISomeInterface StaticProperty { get; set; }
     }
 
     public class ClassWithSetterDependencies : IWithSetterDependencies

--- a/src/NServiceBus.Unity/UnityObjectBuilder.cs
+++ b/src/NServiceBus.Unity/UnityObjectBuilder.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
     using Microsoft.Practices.Unity;
     using ObjectBuilder.Common;
 
@@ -203,7 +204,7 @@
 
         public void SetProperties(Type type, object target, IUnityContainer containerForResolve)
         {
-            var properties = type.GetProperties();
+            var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public);
             foreach (var property in properties)
             {
                 if (!property.CanWrite)


### PR DESCRIPTION
The current behavior was to try inject stuff to all public properties of a given object. That included static properties. This pull filters out the static ones so it now only injects to public instance properties.

### TODO
 - [ ] If this pull is accepted, go and move that added test to the container test suite and verify other containers.