### PR TITLE
Externally owned container is no longer disposed

### DIFF
--- a/src/NServiceBus.Unity.AcceptanceTests/ContainerDecorator.cs
+++ b/src/NServiceBus.Unity.AcceptanceTests/ContainerDecorator.cs
@@ -1,0 +1,77 @@
+﻿namespace ObjectBuilder.Unity.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Practices.Unity;
+
+    class ContainerDecorator : IUnityContainer
+    {
+        public ContainerDecorator(IUnityContainer decorated)
+        {
+            this.decorated = decorated;
+        }
+
+        public bool Disposed { get; private set; }
+
+        public void Dispose()
+        {
+            decorated.Dispose();
+            Disposed = true;
+        }
+
+        public IUnityContainer RegisterType(Type from, Type to, string name, LifetimeManager lifetimeManager, params InjectionMember[] injectionMembers)
+        {
+            return decorated.RegisterType(from, to, name, lifetimeManager, injectionMembers);
+        }
+
+        public IUnityContainer RegisterInstance(Type t, string name, object instance, LifetimeManager lifetime)
+        {
+            return decorated.RegisterInstance(t, name, instance, lifetime);
+        }
+
+        public object Resolve(Type t, string name, params ResolverOverride[] resolverOverrides)
+        {
+            return decorated.Resolve(t, name, resolverOverrides);
+        }
+
+        public IEnumerable<object> ResolveAll(Type t, params ResolverOverride[] resolverOverrides)
+        {
+            return decorated.ResolveAll(t, resolverOverrides);
+        }
+
+        public object BuildUp(Type t, object existing, string name, params ResolverOverride[] resolverOverrides)
+        {
+            return decorated.BuildUp(t, existing, resolverOverrides);
+        }
+
+        public void Teardown(object o)
+        {
+            decorated.Teardown(o);
+        }
+
+        public IUnityContainer AddExtension(UnityContainerExtension extension)
+        {
+            return decorated.AddExtension(extension);
+        }
+
+        public object Configure(Type configurationInterface)
+        {
+            return decorated.Configure(configurationInterface);
+        }
+
+        public IUnityContainer RemoveAllExtensions()
+        {
+            return decorated.RemoveAllExtensions();
+        }
+
+        public IUnityContainer CreateChildContainer()
+        {
+            return decorated.CreateChildContainer();
+        }
+
+        public IUnityContainer Parent => decorated.Parent;
+
+        public IEnumerable<ContainerRegistration> Registrations => decorated.Registrations;
+        private IUnityContainer decorated;
+    }
+}

--- a/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
+++ b/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
@@ -38,6 +38,22 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.6.0.0-rc0001\lib\net452\NServiceBus.AcceptanceTesting.dll</HintPath>
       <Private>True</Private>
@@ -69,6 +85,8 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="When_using_externally_owned_container.cs" />
+    <Compile Include="ContainerDecorator.cs" />
     <Compile Include="DefaultServer.cs" />
     <Compile Include="NServiceBusAcceptanceTest.cs" />
     <Compile Include="When_declaring_a_public_property.cs" />

--- a/src/NServiceBus.Unity.AcceptanceTests/When_using_externally_owned_container.cs
+++ b/src/NServiceBus.Unity.AcceptanceTests/When_using_externally_owned_container.cs
@@ -1,0 +1,49 @@
+﻿namespace ObjectBuilder.Unity.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using Microsoft.Practices.Unity;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_externally_owned_container : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_shutdown_properly()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsFalse(context.Decorator.Disposed);
+            Assert.DoesNotThrow(() => context.Container.Dispose());
+        }
+
+        class Context : ScenarioContext
+        {
+            public IUnityContainer Container { get; set; }
+            public ContainerDecorator Decorator { get; set; }
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((config, desc) =>
+                {
+                    var container = new UnityContainer();
+                    var decorator = new ContainerDecorator(container);
+
+                    config.UseContainer<UnityBuilder>(c => c.UseExistingContainer(decorator));
+
+                    var context = (Context)desc.ScenarioContext;
+                    context.Container = container;
+                    context.Decorator = decorator;
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Unity.AcceptanceTests/packages.config
+++ b/src/NServiceBus.Unity.AcceptanceTests/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NServiceBus.AcceptanceTesting" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NUnit" version="3.2.1" targetFramework="net452" />
+  <package id="Unity" version="4.0.1" targetFramework="net452" />
 </packages>

--- a/src/NServiceBus.Unity.Tests/DisposalTests.cs
+++ b/src/NServiceBus.Unity.Tests/DisposalTests.cs
@@ -1,0 +1,101 @@
+﻿namespace NServiceBus.Unity.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Practices.Unity;
+    using NServiceBus.Unity;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DisposalTests
+    {
+        [Test]
+        public void Owned_container_should_be_disposed()
+        {
+            var fakeContainer = new FakeContainer();
+
+            var container = new UnityObjectBuilder(fakeContainer, true);
+            container.Dispose();
+
+            Assert.True(fakeContainer.Disposed);
+        }
+
+        [Test]
+        public void Externally_owned_container_should_not_be_disposed()
+        {
+            var fakeContainer = new FakeContainer();
+
+            var container = new UnityObjectBuilder(fakeContainer, false);
+            container.Dispose();
+
+            Assert.False(fakeContainer.Disposed);
+        }
+
+        class FakeContainer : IUnityContainer
+        {
+            public bool Disposed { get; private set; }
+
+            public FakeContainer()
+            {
+                Registrations = new List<ContainerRegistration>();
+            }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+
+            public IUnityContainer RegisterType(Type @from, Type to, string name, LifetimeManager lifetimeManager, params InjectionMember[] injectionMembers)
+            {
+                return null;
+            }
+
+            public IUnityContainer RegisterInstance(Type t, string name, object instance, LifetimeManager lifetime)
+            {
+                return null;
+            }
+
+            public object Resolve(Type t, string name, params ResolverOverride[] resolverOverrides)
+            {
+                return null;
+            }
+
+            public IEnumerable<object> ResolveAll(Type t, params ResolverOverride[] resolverOverrides)
+            {
+                yield break;
+            }
+
+            public object BuildUp(Type t, object existing, string name, params ResolverOverride[] resolverOverrides)
+            {
+                return null;
+            }
+
+            public void Teardown(object o)
+            {
+            }
+
+            public IUnityContainer AddExtension(UnityContainerExtension extension)
+            {
+                return null;
+            }
+
+            public object Configure(Type configurationInterface)
+            {
+                return null;
+            }
+
+            public IUnityContainer RemoveAllExtensions()
+            {
+                return null;
+            }
+
+            public IUnityContainer CreateChildContainer()
+            {
+                return null;
+            }
+
+            public IUnityContainer Parent { get; }
+            public IEnumerable<ContainerRegistration> Registrations { get; }
+        }
+    }
+}

--- a/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
@@ -110,6 +110,7 @@
     <Compile Include="BuildAllTests.cs" />
     <Compile Include="BuildTests.cs" />
     <Compile Include="DisposalTests.cs" />
+    <Compile Include="SetUpFixture.cs" />
     <Compile Include="When_object_graph_refers_to_same_dependency_twice.cs" />
     <Compile Include="When_resolving_all.cs" />
     <Compile Include="When_using_existing_container.cs" />

--- a/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_using_nested_containers.cs" />
     <Compile Include="BuildAllTests.cs" />
     <Compile Include="BuildTests.cs" />
+    <Compile Include="DisposalTests.cs" />
     <Compile Include="When_object_graph_refers_to_same_dependency_twice.cs" />
     <Compile Include="When_resolving_all.cs" />
     <Compile Include="When_using_existing_container.cs" />

--- a/src/NServiceBus.Unity.Tests/SetUpFixture.cs
+++ b/src/NServiceBus.Unity.Tests/SetUpFixture.cs
@@ -1,0 +1,14 @@
+﻿namespace NServiceBus.Unity.Tests
+{
+    using NServiceBus.ContainerTests;
+    using NUnit.Framework;
+
+    [SetUpFixture]
+    public class SetUpFixture
+    {
+        public SetUpFixture()
+        {
+            TestContainerBuilder.ConstructBuilder = () => new UnityObjectBuilder();
+        }
+    }
+}

--- a/src/NServiceBus.Unity/UnityBuilder.cs
+++ b/src/NServiceBus.Unity/UnityBuilder.cs
@@ -17,15 +17,25 @@ namespace NServiceBus
         /// <returns>The new container wrapper.</returns>
         public override ObjectBuilder.Common.IContainer CreateContainer(ReadOnlySettings settings)
         {
-            IUnityContainer existingContainer;
+            ContainerHolder containerHolder;
 
-            if (settings.TryGet("ExistingContainer", out existingContainer))
+            if (settings.TryGet(out containerHolder))
             {
-                return new UnityObjectBuilder(existingContainer);
+                return new UnityObjectBuilder(containerHolder.ExistingContainer);
 
             }
 
             return new UnityObjectBuilder();
+        }
+
+        internal class ContainerHolder
+        {
+            public ContainerHolder(IUnityContainer container)
+            {
+                ExistingContainer = container;
+            }
+
+            public IUnityContainer ExistingContainer { get; }
         }
     }
 }

--- a/src/NServiceBus.Unity/UnityConfigExtensions.cs
+++ b/src/NServiceBus.Unity/UnityConfigExtensions.cs
@@ -13,7 +13,7 @@ namespace NServiceBus
         /// </summary>
         public static void UseExistingContainer(this ContainerCustomizations customizations, IUnityContainer existingContainer)
         {
-            customizations.Settings.Set("ExistingContainer", existingContainer);
+            customizations.Settings.Set<UnityBuilder.ContainerHolder>(new UnityBuilder.ContainerHolder(existingContainer));
         }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus/issues/4144

If a user passes us in a kernel instance we will not dispose the container instance. We consider that instance externally owned. This is a behavior breaking change. 

I also had to remove the key access since the SettingsHolder automatically disposes settings values that implement `IDisposable`.

Also makes the component tests actually run with Unity instead of Autofac!