### PR TITLE
Externally owned container is no longer disposed

### DIFF
--- a/src/NServiceBus.Unity.AcceptanceTests/ContainerDecorator.cs
+++ b/src/NServiceBus.Unity.AcceptanceTests/ContainerDecorator.cs
@@ -1,0 +1,77 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Practices.Unity;
+
+    class ContainerDecorator : IUnityContainer
+    {
+        public ContainerDecorator(IUnityContainer decorated)
+        {
+            this.decorated = decorated;
+        }
+
+        public bool Disposed { get; private set; }
+
+        public void Dispose()
+        {
+            decorated.Dispose();
+            Disposed = true;
+        }
+
+        public IUnityContainer RegisterType(Type from, Type to, string name, LifetimeManager lifetimeManager, params InjectionMember[] injectionMembers)
+        {
+            return decorated.RegisterType(from, to, name, lifetimeManager, injectionMembers);
+        }
+
+        public IUnityContainer RegisterInstance(Type t, string name, object instance, LifetimeManager lifetime)
+        {
+            return decorated.RegisterInstance(t, name, instance, lifetime);
+        }
+
+        public object Resolve(Type t, string name, params ResolverOverride[] resolverOverrides)
+        {
+            return decorated.Resolve(t, name, resolverOverrides);
+        }
+
+        public IEnumerable<object> ResolveAll(Type t, params ResolverOverride[] resolverOverrides)
+        {
+            return decorated.ResolveAll(t, resolverOverrides);
+        }
+
+        public object BuildUp(Type t, object existing, string name, params ResolverOverride[] resolverOverrides)
+        {
+            return decorated.BuildUp(t, existing, resolverOverrides);
+        }
+
+        public void Teardown(object o)
+        {
+            decorated.Teardown(o);
+        }
+
+        public IUnityContainer AddExtension(UnityContainerExtension extension)
+        {
+            return decorated.AddExtension(extension);
+        }
+
+        public object Configure(Type configurationInterface)
+        {
+            return decorated.Configure(configurationInterface);
+        }
+
+        public IUnityContainer RemoveAllExtensions()
+        {
+            return decorated.RemoveAllExtensions();
+        }
+
+        public IUnityContainer CreateChildContainer()
+        {
+            return decorated.CreateChildContainer();
+        }
+
+        public IUnityContainer Parent => decorated.Parent;
+
+        public IEnumerable<ContainerRegistration> Registrations => decorated.Registrations;
+        private IUnityContainer decorated;
+    }
+}

--- a/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
+++ b/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
@@ -34,6 +34,22 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.5.1.2\lib\net45\NServiceBus.AcceptanceTesting.dll</HintPath>
@@ -191,6 +207,11 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.1.2\Tx\When_sending_within_an_ambient_transaction.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.1.2\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.1.2\Volatile\When_sending_to_non_durable_endpoint.cs" />
+    <Compile Include="ContainerDecorator.cs" />
+    <Compile Include="When_using_externally_owned_container.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/NServiceBus.Unity.AcceptanceTests/When_using_externally_owned_container.cs
+++ b/src/NServiceBus.Unity.AcceptanceTests/When_using_externally_owned_container.cs
@@ -1,0 +1,48 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using Microsoft.Practices.Unity;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_externally_owned_container : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_shutdown_properly()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsFalse(Endpoint.Context.Decorator.Disposed);
+            Assert.DoesNotThrow(() => Endpoint.Context.Scope.Dispose());
+        }
+
+        class Context : ScenarioContext
+        {
+            public ContainerDecorator Decorator { get; set; }
+            public IUnityContainer Scope { get; set; }
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public static Context Context { get; set; }
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    Context = new Context();
+                    
+                    var container = new UnityContainer();
+                    var scopeDecorator = new ContainerDecorator(container);
+
+                    Context.Decorator = scopeDecorator;
+                    Context.Scope = container;
+
+                    config.UseContainer<UnityBuilder>(c => c.UseExistingContainer(Context.Decorator));
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Unity.AcceptanceTests/packages.config
+++ b/src/NServiceBus.Unity.AcceptanceTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="NServiceBus" version="5.1.2" targetFramework="net45" />
   <package id="NServiceBus.AcceptanceTesting" version="5.1.2" targetFramework="net45" />
   <package id="NServiceBus.AcceptanceTests.Sources" version="5.1.2" targetFramework="net45" />
@@ -9,4 +10,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
+  <package id="Unity" version="4.0.1" targetFramework="net45" />
 </packages>

--- a/src/NServiceBus.Unity.Tests/DisposalTests.cs
+++ b/src/NServiceBus.Unity.Tests/DisposalTests.cs
@@ -1,0 +1,101 @@
+﻿namespace NServiceBus.Unity.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Practices.Unity;
+    using NServiceBus.Unity;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DisposalTests
+    {
+        [Test]
+        public void Owned_container_should_be_disposed()
+        {
+            var fakeContainer = new FakeContainer();
+
+            var container = new UnityObjectBuilder(fakeContainer, new DefaultInstances(), true);
+            container.Dispose();
+
+            Assert.True(fakeContainer.Disposed);
+        }
+
+        [Test]
+        public void Externally_owned_container_should_not_be_disposed()
+        {
+            var fakeContainer = new FakeContainer();
+
+            var container = new UnityObjectBuilder(fakeContainer, new DefaultInstances(), false);
+            container.Dispose();
+
+            Assert.False(fakeContainer.Disposed);
+        }
+
+        class FakeContainer : IUnityContainer
+        {
+            public bool Disposed { get; private set; }
+
+            public FakeContainer()
+            {
+                Registrations = new List<ContainerRegistration>();
+            }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+
+            public IUnityContainer RegisterType(Type @from, Type to, string name, LifetimeManager lifetimeManager, params InjectionMember[] injectionMembers)
+            {
+                return null;
+            }
+
+            public IUnityContainer RegisterInstance(Type t, string name, object instance, LifetimeManager lifetime)
+            {
+                return null;
+            }
+
+            public object Resolve(Type t, string name, params ResolverOverride[] resolverOverrides)
+            {
+                return null;
+            }
+
+            public IEnumerable<object> ResolveAll(Type t, params ResolverOverride[] resolverOverrides)
+            {
+                yield break;
+            }
+
+            public object BuildUp(Type t, object existing, string name, params ResolverOverride[] resolverOverrides)
+            {
+                return null;
+            }
+
+            public void Teardown(object o)
+            {
+            }
+
+            public IUnityContainer AddExtension(UnityContainerExtension extension)
+            {
+                return null;
+            }
+
+            public object Configure(Type configurationInterface)
+            {
+                return null;
+            }
+
+            public IUnityContainer RemoveAllExtensions()
+            {
+                return null;
+            }
+
+            public IUnityContainer CreateChildContainer()
+            {
+                return null;
+            }
+
+            public IUnityContainer Parent { get; }
+            public IEnumerable<ContainerRegistration> Registrations { get; }
+        }
+    }
+}

--- a/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="App_Packages\NSB.ContainerTests.5.1.2\When_using_nested_containers.cs" />
     <Compile Include="BuildAllTests.cs" />
     <Compile Include="BuildTests.cs" />
+    <Compile Include="DisposalTests.cs" />
     <Compile Include="SetUpFixture.cs" />
     <Compile Include="When_resolving_all.cs" />
     <Compile Include="When_using_existing_container.cs" />
@@ -85,6 +86,9 @@
       <Project>{343B2E7A-E228-4B31-ABB5-F5437B2E7A4C}</Project>
       <Name>NServiceBus.Unity</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/NServiceBus.Unity.Tests/SetUpFixture.cs
+++ b/src/NServiceBus.Unity.Tests/SetUpFixture.cs
@@ -10,5 +10,4 @@ public class SetUpFixture
     {
         TestContainerBuilder.ConstructBuilder = () => new UnityObjectBuilder();
     }
-
 }

--- a/src/NServiceBus.Unity/UnityBuilder.cs
+++ b/src/NServiceBus.Unity/UnityBuilder.cs
@@ -17,15 +17,24 @@ namespace NServiceBus
         /// <returns>The new container wrapper.</returns>
         public override ObjectBuilder.Common.IContainer CreateContainer(ReadOnlySettings settings)
         {
-            IUnityContainer existingContainer;
+            ContainerHolder containerHolder;
 
-            if (settings.TryGet("ExistingContainer", out existingContainer))
+            if (settings.TryGet(out containerHolder))
             {
-                return new UnityObjectBuilder(existingContainer);
-
+                return new UnityObjectBuilder(containerHolder.ExistingContainer);
             }
 
             return new UnityObjectBuilder();
         }
+
+        internal class ContainerHolder
+         {
+             public ContainerHolder(IUnityContainer container)
+             {
+                 ExistingContainer = container;
+             }
+ 
+             public IUnityContainer ExistingContainer { get; }
+         }
     }
 }

--- a/src/NServiceBus.Unity/UnityConfigExtensions.cs
+++ b/src/NServiceBus.Unity/UnityConfigExtensions.cs
@@ -13,7 +13,7 @@ namespace NServiceBus
         /// </summary>
         public static void UseExistingContainer(this ContainerCustomizations customizations, IUnityContainer existingContainer)
         {
-            customizations.Settings.Set("ExistingContainer", existingContainer);
+            customizations.Settings.Set<UnityBuilder.ContainerHolder>(new UnityBuilder.ContainerHolder(existingContainer));
         }
     }
 }

--- a/src/NServiceBus.Unity/UnityObjectBuilder.cs
+++ b/src/NServiceBus.Unity/UnityObjectBuilder.cs
@@ -11,17 +11,18 @@
         IUnityContainer container;
         Dictionary<Type, Dictionary<string, object>> configuredProperties = new Dictionary<Type, Dictionary<string, object>>();
         DefaultInstances defaultInstances;
+        private bool owned;
 
         public UnityObjectBuilder()
-            : this(new UnityContainer())
+            : this(new UnityContainer(), new DefaultInstances(), true)
         {
         }
 
         public UnityObjectBuilder(IUnityContainer container)
-            : this(container, new DefaultInstances())
+            : this(container, new DefaultInstances(), false)
         {
             container.AddExtension(new RegisteringNotificationContainerExtension(
-                (from, to, lifetime) => defaultInstances.Add(from), 
+                (from, to, lifetime) => defaultInstances.Add(from),
                 (from, to, lifetime) => defaultInstances.Add(from)));
 
             foreach (var registration in container.Registrations)
@@ -35,8 +36,9 @@
             }
         }
 
-        UnityObjectBuilder(IUnityContainer container, DefaultInstances defaultInstances)
+        public UnityObjectBuilder(IUnityContainer container, DefaultInstances defaultInstances, bool owned)
         {
+            this.owned = owned;
             this.container = container;
             this.defaultInstances = defaultInstances;
 
@@ -53,9 +55,19 @@
             //Injected at compile time
         }
 
+        void DisposeManaged()
+        {
+            if (!owned)
+            {
+                return;
+            }
+
+            container?.Dispose();
+        }
+
         public IContainer BuildChildContainer()
         {
-            return new UnityObjectBuilder(container.CreateChildContainer(), defaultInstances);
+            return new UnityObjectBuilder(container.CreateChildContainer(), defaultInstances, true);
         }
 
         public object Build(Type typeToBuild)


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus/issues/4144

## Who's affected

All users providing an externally created container into the endpoint configuration.

## Symptions

If the externally owned container is disposed all instances marked as `IDisposable `that are registered by NServiceBus will be double disposed which can lead to unwanted side effects and endpoints not being able to properly shut down.

Ping @Particular/container-maintainers 