### PR TITLE
Remove namespace from SetupFixture class

### DIFF
--- a/src/NServiceBus.Unity.Tests/SetUpFixture.cs
+++ b/src/NServiceBus.Unity.Tests/SetUpFixture.cs
@@ -1,14 +1,12 @@
-﻿namespace NServiceBus.Unity.Tests
-{
-    using NServiceBus.ContainerTests;
-    using NUnit.Framework;
+﻿using NServiceBus.ContainerTests;
+using NServiceBus.Unity;
+using NUnit.Framework;
 
-    [SetUpFixture]
-    public class SetUpFixture
+[SetUpFixture]
+public class SetUpFixture
+{
+    public SetUpFixture()
     {
-        public SetUpFixture()
-        {
-            TestContainerBuilder.ConstructBuilder = () => new UnityObjectBuilder();
-        }
+        TestContainerBuilder.ConstructBuilder = () => new UnityObjectBuilder();
     }
 }


### PR DESCRIPTION
Removing the namespace to avoid container tests which aren't located in the specified namespace to fallback to Autofac