### PR TITLE
Add obsolete warnings to NServiceBus.Unity for last major version.

### DIFF
--- a/src/NServiceBus.Unity.Tests/ApprovalTestConfig.cs
+++ b/src/NServiceBus.Unity.Tests/ApprovalTestConfig.cs
@@ -1,6 +1,2 @@
 ﻿using ApprovalTests.Reporters;
-#if(DEBUG)
 [assembly: UseReporter(typeof(DiffReporter), typeof(AllFailingTestsClipboardReporter))]
-#else
-[assembly: UseReporter(typeof(DiffReporter))]
-#endif

--- a/src/NServiceBus.Unity.Tests/NServiceBus.ObjectBuilder.Unity.approved.cs
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.ObjectBuilder.Unity.approved.cs
@@ -2,17 +2,27 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.Unity.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.2", FrameworkDisplayName=".NET Framework 4.5.2")]
-
 namespace NServiceBus
 {
-    
+    [ObsoleteExAttribute(Message="NServiceBus.Unity has been deprecated. Using another container is advised.  Pleas" +
+        "e see https://docs.particular.net/nservicebus/containers/#supported-containers f" +
+        "or a list of supported containers.", TreatAsErrorFromVersion="8.0")]
     public class UnityBuilder : NServiceBus.Container.ContainerDefinition
     {
         public UnityBuilder() { }
+        [ObsoleteExAttribute(Message="NServiceBus.Unity has been deprecated. Using another container is advised.  Pleas" +
+            "e see https://docs.particular.net/nservicebus/containers/#supported-containers f" +
+            "or a list of supported containers.", TreatAsErrorFromVersion="8.0")]
         public override NServiceBus.ObjectBuilder.Common.IContainer CreateContainer(NServiceBus.Settings.ReadOnlySettings settings) { }
     }
+    [ObsoleteExAttribute(Message="NServiceBus.Unity has been deprecated. Using another container is advised.  Pleas" +
+        "e see https://docs.particular.net/nservicebus/containers/#supported-containers f" +
+        "or a list of supported containers.", TreatAsErrorFromVersion="8.0")]
     public class static UnityConfigExtensions
     {
+        [ObsoleteExAttribute(Message="NServiceBus.Unity has been deprecated. Using another container is advised.  Pleas" +
+            "e see https://docs.particular.net/nservicebus/containers/#supported-containers f" +
+            "or a list of supported containers.", TreatAsErrorFromVersion="8.0")]
         public static void UseExistingContainer(this NServiceBus.Container.ContainerCustomizations customizations, Microsoft.Practices.Unity.IUnityContainer existingContainer) { }
     }
 }

--- a/src/NServiceBus.Unity.Tests/NServiceBus.ObjectBuilder.Unity.approved.cs
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.ObjectBuilder.Unity.approved.cs
@@ -5,6 +5,7 @@
 
 namespace NServiceBus
 {
+    
     [ObsoleteExAttribute(Message="NServiceBus.Unity has been deprecated. Using another container is advised.  Pleas" +
         "e see upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="9.0")]
     public class UnityBuilder : NServiceBus.Container.ContainerDefinition

--- a/src/NServiceBus.Unity.Tests/NServiceBus.ObjectBuilder.Unity.approved.cs
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.ObjectBuilder.Unity.approved.cs
@@ -5,24 +5,20 @@
 namespace NServiceBus
 {
     [ObsoleteExAttribute(Message="NServiceBus.Unity has been deprecated. Using another container is advised.  Pleas" +
-        "e see https://docs.particular.net/nservicebus/containers/#supported-containers f" +
-        "or a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+        "e see upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
     public class UnityBuilder : NServiceBus.Container.ContainerDefinition
     {
         public UnityBuilder() { }
         [ObsoleteExAttribute(Message="NServiceBus.Unity has been deprecated. Using another container is advised.  Pleas" +
-            "e see https://docs.particular.net/nservicebus/containers/#supported-containers f" +
-            "or a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+            "e see upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
         public override NServiceBus.ObjectBuilder.Common.IContainer CreateContainer(NServiceBus.Settings.ReadOnlySettings settings) { }
     }
     [ObsoleteExAttribute(Message="NServiceBus.Unity has been deprecated. Using another container is advised.  Pleas" +
-        "e see https://docs.particular.net/nservicebus/containers/#supported-containers f" +
-        "or a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+        "e see upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
     public class static UnityConfigExtensions
     {
         [ObsoleteExAttribute(Message="NServiceBus.Unity has been deprecated. Using another container is advised.  Pleas" +
-            "e see https://docs.particular.net/nservicebus/containers/#supported-containers f" +
-            "or a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+            "e see upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
         public static void UseExistingContainer(this NServiceBus.Container.ContainerCustomizations customizations, Microsoft.Practices.Unity.IUnityContainer existingContainer) { }
     }
 }

--- a/src/NServiceBus.Unity.Tests/NServiceBus.ObjectBuilder.Unity.approved.cs
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.ObjectBuilder.Unity.approved.cs
@@ -2,23 +2,24 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.Unity.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.2", FrameworkDisplayName=".NET Framework 4.5.2")]
+
 namespace NServiceBus
 {
     [ObsoleteExAttribute(Message="NServiceBus.Unity has been deprecated. Using another container is advised.  Pleas" +
-        "e see upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+        "e see upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="9.0")]
     public class UnityBuilder : NServiceBus.Container.ContainerDefinition
     {
         public UnityBuilder() { }
         [ObsoleteExAttribute(Message="NServiceBus.Unity has been deprecated. Using another container is advised.  Pleas" +
-            "e see upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+            "e see upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="9.0")]
         public override NServiceBus.ObjectBuilder.Common.IContainer CreateContainer(NServiceBus.Settings.ReadOnlySettings settings) { }
     }
     [ObsoleteExAttribute(Message="NServiceBus.Unity has been deprecated. Using another container is advised.  Pleas" +
-        "e see upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+        "e see upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="9.0")]
     public class static UnityConfigExtensions
     {
         [ObsoleteExAttribute(Message="NServiceBus.Unity has been deprecated. Using another container is advised.  Pleas" +
-            "e see upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="8.0")]
+            "e see upgrade guide for a list of supported containers.", TreatAsErrorFromVersion="9.0")]
         public static void UseExistingContainer(this NServiceBus.Container.ContainerCustomizations customizations, Microsoft.Practices.Unity.IUnityContainer existingContainer) { }
     }
 }

--- a/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
@@ -22,4 +22,7 @@
     <PackageReference Include="NServiceBus.ContainerTests.Sources" Version="7.0.0-alpharelease0051" />
     <ProjectReference Include="..\NServiceBus.Unity\NServiceBus.Unity.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/src/NServiceBus.Unity/UnityBuilder.cs
+++ b/src/NServiceBus.Unity/UnityBuilder.cs
@@ -9,7 +9,7 @@ namespace NServiceBus
     /// Unity Container
     /// </summary>
     [ObsoleteEx(Message = obsolete.Message,
-        TreatAsErrorFromVersion = "8.0")]
+        TreatAsErrorFromVersion = "9.0")]
     public class UnityBuilder : ContainerDefinition
     {
         /// <summary>
@@ -18,7 +18,7 @@ namespace NServiceBus
         /// <param name="settings">The settings to check if an existing container exists.</param>
         /// <returns>The new container wrapper.</returns>
         [ObsoleteEx(Message = obsolete.Message,
-            TreatAsErrorFromVersion = "8.0")]
+            TreatAsErrorFromVersion = "9.0")]
         public override ObjectBuilder.Common.IContainer CreateContainer(ReadOnlySettings settings)
         {
             ContainerHolder containerHolder;

--- a/src/NServiceBus.Unity/UnityBuilder.cs
+++ b/src/NServiceBus.Unity/UnityBuilder.cs
@@ -8,6 +8,8 @@ namespace NServiceBus
     /// <summary>
     /// Unity Container
     /// </summary>
+    [ObsoleteEx(Message = obsolete.Message,
+        TreatAsErrorFromVersion = "8.0")]
     public class UnityBuilder : ContainerDefinition
     {
         /// <summary>
@@ -15,6 +17,8 @@ namespace NServiceBus
         /// </summary>
         /// <param name="settings">The settings to check if an existing container exists.</param>
         /// <returns>The new container wrapper.</returns>
+        [ObsoleteEx(Message = obsolete.Message,
+            TreatAsErrorFromVersion = "8.0")]
         public override ObjectBuilder.Common.IContainer CreateContainer(ReadOnlySettings settings)
         {
             ContainerHolder containerHolder;

--- a/src/NServiceBus.Unity/UnityConfigExtensions.cs
+++ b/src/NServiceBus.Unity/UnityConfigExtensions.cs
@@ -6,11 +6,15 @@ namespace NServiceBus
     /// <summary>
     /// Extensions for unity specific config
     /// </summary>
+    [ObsoleteEx(Message = obsolete.Message,
+        TreatAsErrorFromVersion = "8.0")]
     public static class UnityConfigExtensions
     {
         /// <summary>
         /// Use the a pre-configured <see cref="IUnityContainer"/>.
         /// </summary>
+        [ObsoleteEx(Message = obsolete.Message,
+            TreatAsErrorFromVersion = "8.0")]
         public static void UseExistingContainer(this ContainerCustomizations customizations, IUnityContainer existingContainer)
         {
             customizations.Settings.Set<UnityBuilder.ContainerHolder>(new UnityBuilder.ContainerHolder(existingContainer));

--- a/src/NServiceBus.Unity/UnityConfigExtensions.cs
+++ b/src/NServiceBus.Unity/UnityConfigExtensions.cs
@@ -7,14 +7,14 @@ namespace NServiceBus
     /// Extensions for unity specific config
     /// </summary>
     [ObsoleteEx(Message = obsolete.Message,
-        TreatAsErrorFromVersion = "8.0")]
+        TreatAsErrorFromVersion = "9.0")]
     public static class UnityConfigExtensions
     {
         /// <summary>
         /// Use the a pre-configured <see cref="IUnityContainer"/>.
         /// </summary>
         [ObsoleteEx(Message = obsolete.Message,
-            TreatAsErrorFromVersion = "8.0")]
+            TreatAsErrorFromVersion = "9.0")]
         public static void UseExistingContainer(this ContainerCustomizations customizations, IUnityContainer existingContainer)
         {
             customizations.Settings.Set<UnityBuilder.ContainerHolder>(new UnityBuilder.ContainerHolder(existingContainer));

--- a/src/NServiceBus.Unity/obsolete.cs
+++ b/src/NServiceBus.Unity/obsolete.cs
@@ -1,0 +1,7 @@
+﻿namespace NServiceBus
+{
+    class obsolete
+    {
+        internal const string Message = "NServiceBus.Unity has been deprecated. Using another container is advised.  Please see https://docs.particular.net/nservicebus/containers/#supported-containers for a list of supported containers.";
+    }
+}

--- a/src/NServiceBus.Unity/obsolete.cs
+++ b/src/NServiceBus.Unity/obsolete.cs
@@ -2,6 +2,6 @@
 {
     class obsolete
     {
-        internal const string Message = "NServiceBus.Unity has been deprecated. Using another container is advised.  Please see https://docs.particular.net/nservicebus/containers/#supported-containers for a list of supported containers.";
+        internal const string Message = "NServiceBus.Unity has been deprecated. Using another container is advised.  Please see upgrade guide for a list of supported containers.";
     }
 }


### PR DESCRIPTION
The [last Nuget package release of Unity](https://www.nuget.org/packages/Unity/) was 2015-10-16. Last commit to the [Unity repo](https://github.com/unitycontainer/unity) was 2016-03-18. Only one person has made commits to the project since it [was transferred from Microsoft to the community](https://blogs.msdn.microsoft.com/dotnet/2015/08/21/the-future-of-unity/). Any attempt to move it to .Net standard appears to be stalled. No community PRs have been accepted, and only one has even been commented on by the maintainers.

We should drop support for Unity and encourage our users to choose another container and migrate away from Unity. This PR would make it official.