### PR TITLE
Netstandard support

### DIFF
--- a/src/NServiceBus.Unity.AcceptanceTests/ContainerDecorator.cs
+++ b/src/NServiceBus.Unity.AcceptanceTests/ContainerDecorator.cs
@@ -2,7 +2,11 @@
 {
     using System;
     using System.Collections.Generic;
-    using Microsoft.Practices.Unity;
+    using global::Unity;
+    using global::Unity.Extension;
+    using global::Unity.Lifetime;
+    using global::Unity.Registration;
+    using global::Unity.Resolution;
 
     class ContainerDecorator : IUnityContainer
     {
@@ -46,7 +50,6 @@
 
         public void Teardown(object o)
         {
-            decorated.Teardown(o);
         }
 
         public IUnityContainer AddExtension(UnityContainerExtension extension)
@@ -71,7 +74,7 @@
 
         public IUnityContainer Parent => decorated.Parent;
 
-        public IEnumerable<ContainerRegistration> Registrations => decorated.Registrations;
+        public IEnumerable<IContainerRegistration> Registrations => decorated.Registrations;
         private IUnityContainer decorated;
     }
 }

--- a/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
+++ b/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
@@ -10,11 +10,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Unity" Version="[5.0.0,6.0.0)" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <!-- Do not use wildcards with Unity : https://github.com/unitycontainer/unity/issues/32 -->
-    <PackageReference Include="Unity" Version="[5.0.0,6.0.0)" />
   </ItemGroup>
 </Project>

--- a/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
+++ b/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
@@ -15,8 +15,6 @@
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
     <!-- Do not use wildcards with Unity : https://github.com/unitycontainer/unity/issues/32 -->
-    <PackageReference Include="Unity" Version="4.0.1" />
-    <PackageReference Include="Unity.Interception" Version="4.0.1" />
+    <PackageReference Include="Unity" Version="[5.0.0,6.0.0)" />
   </ItemGroup>
-
 </Project>

--- a/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
+++ b/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity" Version="[5.0.0,6.0.0)" />
+    <PackageReference Include="Unity" Version="[5.0.1,6.0.0)" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-*" />
   </ItemGroup>
 

--- a/src/NServiceBus.Unity.AcceptanceTests/When_using_externally_owned_container.cs
+++ b/src/NServiceBus.Unity.AcceptanceTests/When_using_externally_owned_container.cs
@@ -1,7 +1,7 @@
 ﻿namespace ObjectBuilder.Unity.AcceptanceTests
 {
     using System.Threading.Tasks;
-    using Microsoft.Practices.Unity;
+    using global::Unity;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests;

--- a/src/NServiceBus.Unity.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Unity.Tests/APIApprovals.Approve.approved.txt
@@ -11,6 +11,6 @@ namespace NServiceBus
     }
     public class static UnityConfigExtensions
     {
-        public static void UseExistingContainer(this NServiceBus.Container.ContainerCustomizations customizations, Microsoft.Practices.Unity.IUnityContainer existingContainer) { }
+        public static void UseExistingContainer(this NServiceBus.Container.ContainerCustomizations customizations, Unity.IUnityContainer existingContainer) { }
     }
 }

--- a/src/NServiceBus.Unity.Tests/APIApprovals.cs
+++ b/src/NServiceBus.Unity.Tests/APIApprovals.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NET452
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -31,3 +32,4 @@ public class APIApprovals
             );
     }
 }
+#endif

--- a/src/NServiceBus.Unity.Tests/ApprovalTestConfig.cs
+++ b/src/NServiceBus.Unity.Tests/ApprovalTestConfig.cs
@@ -1,6 +1,4 @@
-﻿using ApprovalTests.Reporters;
-#if(DEBUG)
+﻿#if NET452
+using ApprovalTests.Reporters;
 [assembly: UseReporter(typeof(DiffReporter), typeof(AllFailingTestsClipboardReporter))]
-#else
-[assembly: UseReporter(typeof(DiffReporter))]
 #endif

--- a/src/NServiceBus.Unity.Tests/DisposalTests.cs
+++ b/src/NServiceBus.Unity.Tests/DisposalTests.cs
@@ -2,7 +2,12 @@
 {
     using System;
     using System.Collections.Generic;
-    using Microsoft.Practices.Unity;
+    using global::Unity;
+    using global::Unity.Container.Registration;
+    using global::Unity.Extension;
+    using global::Unity.Lifetime;
+    using global::Unity.Registration;
+    using global::Unity.Resolution;
     using NServiceBus.Unity;
     using NUnit.Framework;
 
@@ -95,7 +100,7 @@
             }
 
             public IUnityContainer Parent { get; }
-            public IEnumerable<ContainerRegistration> Registrations { get; }
+            public IEnumerable<IContainerRegistration> Registrations { get; }
         }
     }
 }

--- a/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
@@ -14,12 +14,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Unity.Container" Version="[5.0.0,6.0.0)" />
     <PackageReference Include="NServiceBus.ContainerTests.Sources" Version="7.0.0-*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <!-- Do not use wildcards with Unity : https://github.com/unitycontainer/unity/issues/32 -->
-    <PackageReference Include="Unity" Version="[5.0.0,6.0.0)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">

--- a/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Unity\NServiceBus.Unity.csproj" />
+    <None Remove="APIApprovals.Approve.received.txt" />
     <None Remove="NServiceBus.Unity.Tests.csproj.DotSettings" />
   </ItemGroup>
 
@@ -18,13 +19,11 @@
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
     <!-- Do not use wildcards with Unity : https://github.com/unitycontainer/unity/issues/32 -->
-    <PackageReference Include="Unity" Version="4.0.1" />
-    <PackageReference Include="Unity.Interception" Version="4.0.1" />
+    <PackageReference Include="Unity" Version="[5.0.0,6.0.0)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="PublicApiGenerator" Version="6.4.0" />
   </ItemGroup>
-
 </Project>

--- a/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity.Container" Version="[5.0.0,6.0.0)" />
+    <PackageReference Include="Unity.Container" Version="[5.0.1,6.0.0)" />
     <PackageReference Include="NServiceBus.ContainerTests.Sources" Version="7.0.0-*" />
   </ItemGroup>
 

--- a/src/NServiceBus.Unity.Tests/When_object_graph_refers_to_same_dependency_twice.cs
+++ b/src/NServiceBus.Unity.Tests/When_object_graph_refers_to_same_dependency_twice.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.ContainerTests
 {
-    using Microsoft.Practices.Unity;
+    using global::Unity;
+    using global::Unity.Lifetime;
     using NServiceBus.Unity;
     using NUnit.Framework;
 
@@ -10,13 +11,13 @@ namespace NServiceBus.ContainerTests
         [Test]
         public void It_should_be_created_as_a_single_instance()
         {
-            var conainer = new UnityContainer();
+            var container = new UnityContainer();
 
-            conainer.RegisterType<Root, Root>();
-            conainer.RegisterType<ServiceA, ServiceA>(new PerResolveLifetimeManager());
-            conainer.RegisterType<ServiceB, ServiceB>();
+            container.RegisterType<Root, Root>();
+            container.RegisterType<ServiceA, ServiceA>(new PerResolveLifetimeManager());
+            container.RegisterType<ServiceB, ServiceB>();
 
-            using (var builder = new UnityObjectBuilder(conainer))
+            using (var builder = new UnityObjectBuilder(container))
             {
                 var root = (Root)builder.Build(typeof(Root));
 

--- a/src/NServiceBus.Unity.Tests/When_using_existing_container.cs
+++ b/src/NServiceBus.Unity.Tests/When_using_existing_container.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Linq;
     using System.Threading.Tasks;
-    using Microsoft.Practices.Unity;
+    using global::Unity;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/NServiceBus.Unity/NServiceBus.Unity.csproj
+++ b/src/NServiceBus.Unity/NServiceBus.Unity.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Unity.Abstractions" Version="[2.0.1,3.0.0)" />
     <PackageReference Include="Unity.Container" Version="[5.0.0,6.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-beta0009,8.0.0)" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />

--- a/src/NServiceBus.Unity/NServiceBus.Unity.csproj
+++ b/src/NServiceBus.Unity/NServiceBus.Unity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <AssemblyName>NServiceBus.ObjectBuilder.Unity</AssemblyName>
     <RootNamespace>NServiceBus.ObjectBuilder.Unity</RootNamespace>
     <SignAssembly>true</SignAssembly>
@@ -14,13 +14,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity" Version="[4.0.1,5.0.0)" />
-    <PackageReference Include="Unity.Interception" Version="[4.0.1,5.0.0)" />
+    <PackageReference Include="Unity.Container" Version="[5.0.0,6.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-beta0009,8.0.0)" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.*" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="*" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>
-
 </Project>

--- a/src/NServiceBus.Unity/NServiceBus.Unity.csproj
+++ b/src/NServiceBus.Unity/NServiceBus.Unity.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity.Abstractions" Version="[2.0.1,3.0.0)" />
-    <PackageReference Include="Unity.Container" Version="[5.0.0,6.0.0)" />
+    <PackageReference Include="Unity.Abstractions" Version="[2.0.2,3.0.0)" />
+    <PackageReference Include="Unity.Container" Version="[5.0.1,6.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-beta0009,8.0.0)" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.*" PrivateAssets="All" />

--- a/src/NServiceBus.Unity/PropertyInjectionBuilderStrategy.cs
+++ b/src/NServiceBus.Unity/PropertyInjectionBuilderStrategy.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Unity
 {
-    using Microsoft.Practices.ObjectBuilder2;
+    using global::Unity.Builder;
+    using global::Unity.Builder.Strategy;
 
     class PropertyInjectionBuilderStrategy : BuilderStrategy
     {

--- a/src/NServiceBus.Unity/PropertyInjectionContainerExtension.cs
+++ b/src/NServiceBus.Unity/PropertyInjectionContainerExtension.cs
@@ -1,7 +1,7 @@
 namespace NServiceBus.Unity
 {
-    using Microsoft.Practices.Unity;
-    using Microsoft.Practices.Unity.ObjectBuilder;
+    using global::Unity.Builder;
+    using global::Unity.Extension;
 
     class PropertyInjectionContainerExtension : UnityContainerExtension
     {

--- a/src/NServiceBus.Unity/RegisteringNotificationContainerExtension.cs
+++ b/src/NServiceBus.Unity/RegisteringNotificationContainerExtension.cs
@@ -1,7 +1,9 @@
 namespace NServiceBus.Unity
 {
     using System;
-    using Microsoft.Practices.Unity;
+    using global::Unity.Events;
+    using global::Unity.Extension;
+    using global::Unity.Lifetime;
 
     class RegisteringNotificationContainerExtension : UnityContainerExtension
     {

--- a/src/NServiceBus.Unity/SingletonLifetimeManager.cs
+++ b/src/NServiceBus.Unity/SingletonLifetimeManager.cs
@@ -1,8 +1,8 @@
 ﻿namespace NServiceBus.Unity
 {
     using System;
-    using Microsoft.Practices.ObjectBuilder2;
-    using Microsoft.Practices.Unity;
+    using global::Unity.Exceptions;
+    using global::Unity.Lifetime;
 
     [Janitor.SkipWeaving]
     class SingletonLifetimeManager : LifetimeManager, IRequiresRecovery, IDisposable

--- a/src/NServiceBus.Unity/UnityBuilder.cs
+++ b/src/NServiceBus.Unity/UnityBuilder.cs
@@ -1,7 +1,7 @@
 namespace NServiceBus
 {
     using Container;
-    using Microsoft.Practices.Unity;
+    using global::Unity;
     using Settings;
     using Unity;
 

--- a/src/NServiceBus.Unity/UnityConfigExtensions.cs
+++ b/src/NServiceBus.Unity/UnityConfigExtensions.cs
@@ -1,7 +1,7 @@
 namespace NServiceBus
 {
     using Container;
-    using Microsoft.Practices.Unity;
+    using global::Unity;
 
     /// <summary>
     /// Extensions for unity specific config

--- a/src/NServiceBus.Unity/UnityObjectBuilder.cs
+++ b/src/NServiceBus.Unity/UnityObjectBuilder.cs
@@ -3,7 +3,9 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Microsoft.Practices.Unity;
+    using global::Unity;
+    using global::Unity.Injection;
+    using global::Unity.Lifetime;
     using NServiceBus.ObjectBuilder.Common;
 
     class UnityObjectBuilder : IContainer
@@ -140,8 +142,6 @@
 
         public void Release(object instance)
         {
-            //Not sure if I need to call this or not!
-            container.Teardown(instance);
         }
 
         bool HasDefaultInstanceOf(Type typeToBuild)


### PR DESCRIPTION
With the 5.0 release Unity now supports netstandard. This PR modifies our project to support netstandard.

Unfortunately Unity has dropped the `CLSCompliant` attribute and is no longer marked as CLS compliant, which our assembly is. I have submitted [a PR to Unity.Abstractions](https://github.com/unitycontainer/abstractions/pull/13) to add CLS compliance. Until that is merged and released we cannot merge and release this PR.

We will have to set the minimum version to a more appropriate value when they release a version with the attribute.