### PR TITLE
Update to NServiceBus beta10

### DIFF
--- a/src/NServiceBus.Unity/NServiceBus.Unity.csproj
+++ b/src/NServiceBus.Unity/NServiceBus.Unity.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Unity.Abstractions" Version="[2.0.2,3.0.0)" />
     <PackageReference Include="Unity.Container" Version="[5.0.1,6.0.0)" />
-    <PackageReference Include="NServiceBus" Version="[7.0.0-beta0009,8.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[7.0.0-beta0010,8.0.0)" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.*" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="*" PrivateAssets="All" />


### PR DESCRIPTION
beta10 contains a breaking change around the `AddStartupDiagnosticsSection` extension method, see https://github.com/Particular/NServiceBus/pull/5039/files and therefore needs to be recompiled against beta10.