### PR TITLE
Update unity to 5.7.3

### DIFF
--- a/src/NServiceBus.Unity.AcceptanceTests/ContainerDecorator.cs
+++ b/src/NServiceBus.Unity.AcceptanceTests/ContainerDecorator.cs
@@ -62,11 +62,6 @@
             return decorated.Configure(configurationInterface);
         }
 
-        public IUnityContainer RemoveAllExtensions()
-        {
-            return decorated.RemoveAllExtensions();
-        }
-
         public IUnityContainer CreateChildContainer()
         {
             return decorated.CreateChildContainer();

--- a/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
+++ b/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity" Version="5.5.4" />
+    <PackageReference Include="Unity" Version="5.8.4" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-beta0012" />
   </ItemGroup>
 

--- a/src/NServiceBus.Unity.AcceptanceTests/When_declaring_a_public_property.cs
+++ b/src/NServiceBus.Unity.AcceptanceTests/When_declaring_a_public_property.cs
@@ -15,7 +15,7 @@
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.When((bus, c) => bus.SendLocal(new MyMessage())))
                 .Done(c => c.WasCalled)
-                .Run();
+                .Run().ConfigureAwait(false);
 
             Assert.IsTrue(context.PropertyWasInjected);
         }

--- a/src/NServiceBus.Unity.AcceptanceTests/When_setting_properties_explicitly_via_the_container.cs
+++ b/src/NServiceBus.Unity.AcceptanceTests/When_setting_properties_explicitly_via_the_container.cs
@@ -28,7 +28,7 @@
                     b.When((bus, c) => bus.SendLocal(new MyMessage()));
                 })
                 .Done(c => c.WasCalled)
-                .Run();
+                .Run().ConfigureAwait(false);
 
             Assert.AreEqual(simpleValue, context.PropertyValue);
         }

--- a/src/NServiceBus.Unity.AcceptanceTests/When_using_externally_owned_container.cs
+++ b/src/NServiceBus.Unity.AcceptanceTests/When_using_externally_owned_container.cs
@@ -16,7 +16,7 @@
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>()
                 .Done(c => c.EndpointsStarted)
-                .Run();
+                .Run().ConfigureAwait(false);
 
             Assert.IsFalse(context.Decorator.Disposed);
             Assert.DoesNotThrow(() => context.Container.Dispose());

--- a/src/NServiceBus.Unity.Tests/DisposalTests.cs
+++ b/src/NServiceBus.Unity.Tests/DisposalTests.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using global::Unity;
-    using global::Unity.Container.Registration;
     using global::Unity.Extension;
     using global::Unity.Lifetime;
     using global::Unity.Registration;

--- a/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity.Container" Version="5.5.3" />
+    <PackageReference Include="Unity.Container" Version="5.8.4" />
     <PackageReference Include="NServiceBus.ContainerTests.Sources" Version="7.0.0-beta0012" />
   </ItemGroup>
 

--- a/src/NServiceBus.Unity/NServiceBus.Unity.csproj
+++ b/src/NServiceBus.Unity/NServiceBus.Unity.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" />
-    <PackageReference Include="Unity.Container" Version="[5.5.3, 6.0.0)" />
+    <PackageReference Include="Unity.Container" Version="5.7.3" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-beta0012, 8.0.0)" />
     <PackageReference Include="Fody" Version="3.0.1" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.6.0" PrivateAssets="All" />

--- a/src/NServiceBus.Unity/NServiceBus.Unity.csproj
+++ b/src/NServiceBus.Unity/NServiceBus.Unity.csproj
@@ -14,11 +14,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Particular.CodeRules" Version="0.2.0" />
     <PackageReference Include="Unity.Container" Version="[5.5.3, 6.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-beta0012, 8.0.0)" />
-    <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
-    <PackageReference Include="Janitor.Fody" Version="1.*" PrivateAssets="All" />
-    <PackageReference Include="Particular.CodeRules" Version="*" PrivateAssets="All" />
+    <PackageReference Include="Fody" Version="3.0.1" PrivateAssets="All" />
+    <PackageReference Include="Janitor.Fody" Version="1.6.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.Unity/PropertyInjectionBuilderStrategy.cs
+++ b/src/NServiceBus.Unity/PropertyInjectionBuilderStrategy.cs
@@ -1,11 +1,13 @@
 namespace NServiceBus.Unity
 {
+    using System;
     using global::Unity.Builder;
     using global::Unity.Builder.Strategy;
 
     class PropertyInjectionBuilderStrategy : BuilderStrategy
     {
         UnityObjectBuilder unityContainer;
+        bool mustSetProperties = true;
 
         public PropertyInjectionBuilderStrategy(UnityObjectBuilder unityContainer)
         {
@@ -14,12 +16,20 @@ namespace NServiceBus.Unity
 
         public override void PreBuildUp(IBuilderContext context)
         {
-            var type = context.BuildKey.Type;
-            var target = context.Existing;
-            if (!type.FullName.StartsWith("Microsoft.Practices") || !type.FullName.StartsWith("Unity."))
+            if (mustSetProperties)
             {
-                unityContainer.SetProperties(target.GetType(), target, t => context.NewBuildUp(t, null));
+                var type = context.BuildKey.Type;
+                var target = context.Existing;
+                if (!type.FullName.StartsWith("Microsoft.Practices") || !type.FullName.StartsWith("Unity."))
+                {
+                    unityContainer.SetProperties(target.GetType(), target, t => context.NewBuildUp(t, null));
+                }
             }
+        }
+
+        public void Stop()
+        {
+            mustSetProperties = false;
         }
     }
 }

--- a/src/NServiceBus.Unity/PropertyInjectionBuilderStrategy.cs
+++ b/src/NServiceBus.Unity/PropertyInjectionBuilderStrategy.cs
@@ -12,15 +12,14 @@ namespace NServiceBus.Unity
             this.unityContainer = unityContainer;
         }
 
-        public override object PreBuildUp(IBuilderContext context)
+        public override void PreBuildUp(IBuilderContext context)
         {
             var type = context.BuildKey.Type;
             var target = context.Existing;
             if (!type.FullName.StartsWith("Microsoft.Practices") || !type.FullName.StartsWith("Unity."))
             {
-                unityContainer.SetProperties(target.GetType(), target, t => context.NewBuildUp(new NamedTypeBuildKey(t)));
+                unityContainer.SetProperties(target.GetType(), target, t => context.NewBuildUp(t, null));
             }
-            return null;
         }
     }
 }

--- a/src/NServiceBus.Unity/PropertyInjectionContainerExtension.cs
+++ b/src/NServiceBus.Unity/PropertyInjectionContainerExtension.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Unity
 {
     using global::Unity.Builder;
     using global::Unity.Extension;
+    using global::Unity.Registration;
 
     class PropertyInjectionContainerExtension : UnityContainerExtension
     {
@@ -14,7 +15,13 @@ namespace NServiceBus.Unity
 
         protected override void Initialize()
         {
-            Context.Strategies.Add(new PropertyInjectionBuilderStrategy(unityObjectBuilder), UnityBuildStage.Initialization);
+            var propertyInjectionStrategy = new PropertyInjectionBuilderStrategy(unityObjectBuilder);
+            Context.Strategies.Add(propertyInjectionStrategy, UnityBuildStage.Initialization);
+
+            foreach (ContainerRegistration registration in Context.Lifetime.Container.Registrations)
+            {
+                registration.BuildChain.Add(propertyInjectionStrategy);
+            }
         }
     }
 }

--- a/src/NServiceBus.Unity/PropertyInjectionContainerExtension.cs
+++ b/src/NServiceBus.Unity/PropertyInjectionContainerExtension.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Unity
 {
+    using System;
     using global::Unity.Builder;
     using global::Unity.Extension;
     using global::Unity.Registration;
@@ -7,6 +8,7 @@ namespace NServiceBus.Unity
     class PropertyInjectionContainerExtension : UnityContainerExtension
     {
         UnityObjectBuilder unityObjectBuilder;
+        PropertyInjectionBuilderStrategy propertyInjectionStrategy;
 
         public PropertyInjectionContainerExtension(UnityObjectBuilder unityObjectBuilder)
         {
@@ -15,13 +17,18 @@ namespace NServiceBus.Unity
 
         protected override void Initialize()
         {
-            var propertyInjectionStrategy = new PropertyInjectionBuilderStrategy(unityObjectBuilder);
+            propertyInjectionStrategy = new PropertyInjectionBuilderStrategy(unityObjectBuilder);
             Context.Strategies.Add(propertyInjectionStrategy, UnityBuildStage.Initialization);
 
             foreach (ContainerRegistration registration in Context.Lifetime.Container.Registrations)
             {
                 registration.BuildChain.Add(propertyInjectionStrategy);
             }
+        }
+
+        public void Stop()
+        {
+            propertyInjectionStrategy.Stop();
         }
     }
 }

--- a/src/NServiceBus.Unity/UnityObjectBuilder.cs
+++ b/src/NServiceBus.Unity/UnityObjectBuilder.cs
@@ -58,6 +58,8 @@
 
         void DisposeManaged()
         {
+            container.Configure<PropertyInjectionContainerExtension>()?.Stop();
+
             if (!owned)
             {
                 return;


### PR DESCRIPTION
Also fixes a bug with using a disposed UnityObjectBuilder, and updates Fody and a couple other dependencies.

All separate commits so can be removed if required.