### PR TITLE
Limit upper package unity dependency boundary

### DIFF
--- a/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
+++ b/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
+++ b/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity.Container" Version="5.8.6" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.1" />
+    <PackageReference Include="Unity.Container" Version="5.8.13" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.1.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
@@ -12,8 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity.Container" Version="5.8.6" />
-    <PackageReference Include="NServiceBus.ContainerTests.Sources" Version="7.0.1" />
+    <PackageReference Include="NServiceBus.ContainerTests.Sources" Version="7.1.6" />
+    <PackageReference Include="Unity.Container" Version="5.8.13" />
+    <PackageReference Include="NServiceBus" Version="7.1.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -14,7 +14,6 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus.ContainerTests.Sources" Version="7.1.6" />
     <PackageReference Include="Unity.Container" Version="5.8.13" />
-    <PackageReference Include="NServiceBus" Version="7.1.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Unity/NServiceBus.Unity.csproj
+++ b/src/NServiceBus.Unity/NServiceBus.Unity.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity.Container" Version="[5.8.6, 6.0.0)" />
+    <PackageReference Include="Unity.Container" Version="[5.8.6, 5.9.0)" />
     <PackageReference Include="NServiceBus" Version="[7.0.1, 8.0.0)" />
     <PackageReference Include="Fody" Version="3.3.5" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.6.5" PrivateAssets="All" />


### PR DESCRIPTION
relates to https://github.com/Particular/NServiceBus.Unity/issues/100
Prevent users from referencing Unity 5.9.x while using NServiceBus.Unity 9.0