### PR TITLE
Avoid StackOverflowExceptions when resolving recursive properties

### DIFF
--- a/src/NServiceBus.Unity.Tests/RecursiveTests.cs
+++ b/src/NServiceBus.Unity.Tests/RecursiveTests.cs
@@ -1,0 +1,35 @@
+﻿namespace NServiceBus.Unity.Tests
+{
+    using ContainerTests;
+    using NUnit.Framework;
+
+    // Remove this tests once the NServiceBus.ContainerTests.Sources package has been upates to 7.2 as it contains this test
+    [TestFixture]
+    public class RecursiveTests
+    {
+        [Test]
+        public void Resolving_recursive_types_with_singleton_does_not_stack_overflow()
+        {
+            using (var builder = TestContainerBuilder.ConstructBuilder())
+            {
+                builder.RegisterSingleton(typeof(RecursiveComponent), new RecursiveComponent());
+                builder.Build(typeof(RecursiveComponent));
+            }
+        }
+
+        [Test]
+        public void Resolving_recursive_types_with_factory_does_not_stack_overflow()
+        {
+            using (var builder = TestContainerBuilder.ConstructBuilder())
+            {
+                builder.Configure(() => new RecursiveComponent(), DependencyLifecycle.SingleInstance);
+                builder.Build(typeof(RecursiveComponent));
+            }
+        }
+    }
+
+    public class RecursiveComponent
+    {
+        public RecursiveComponent Instance { get; set; }
+    }
+}

--- a/src/NServiceBus.Unity/SingletonLifetimeManager.cs
+++ b/src/NServiceBus.Unity/SingletonLifetimeManager.cs
@@ -5,7 +5,7 @@
 
     [Janitor.SkipWeaving]
     //TODO: consider removing this implementation in favor of Unity.Lifetime.SingletonLifetimeManager
-    class SingletonLifetimeManager : LifetimeManager, IDisposable, IFactoryLifetimeManager, ITypeLifetimeManager
+    class SingletonLifetimeManager : LifetimeManager, IDisposable, IFactoryLifetimeManager, ITypeLifetimeManager, IInstanceLifetimeManager
     {
         SingletonInstanceStore instanceStore;
         protected override LifetimeManager OnCreateLifetimeManager()

--- a/src/NServiceBus.Unity/UnityObjectBuilder.cs
+++ b/src/NServiceBus.Unity/UnityObjectBuilder.cs
@@ -230,9 +230,15 @@
                     continue;
                 }
 
-                if (HasDefaultInstanceOf(property.PropertyType))
+                var propertyType = property.PropertyType;
+                if (HasDefaultInstanceOf(propertyType))
                 {
-                    property.SetValue(target, resolveMethod(property.PropertyType), null);
+                    if (type == propertyType)
+                    {
+                        // skip recursive properties
+                        continue;
+                    }
+                    property.SetValue(target, resolveMethod(propertyType), null);
                 }
             }
         }

--- a/src/NServiceBus.Unity/UnityObjectBuilder.cs
+++ b/src/NServiceBus.Unity/UnityObjectBuilder.cs
@@ -136,7 +136,7 @@
         public void RegisterSingleton(Type lookupType, object instance)
         {
             defaultInstances.Add(lookupType);
-            container.RegisterFactory(lookupType, unityContainer => instance, new SingletonLifetimeManager(new SingletonInstanceStore()));
+            container.RegisterInstance(lookupType, instance, new SingletonLifetimeManager(new SingletonInstanceStore()));
         }
 
         public bool HasComponent(Type componentType)


### PR DESCRIPTION
fixes https://github.com/Particular/NServiceBus.Unity/issues/95

currently depends on the 5.9 update branch