### PR TITLE
create a test for the broken factory injection

### DIFF
--- a/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
+++ b/src/NServiceBus.Unity.AcceptanceTests/NServiceBus.Unity.AcceptanceTests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity.Container" Version="5.10.1" />
+    <PackageReference Include="Unity.Container" Version="5.11.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />

--- a/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
+++ b/src/NServiceBus.Unity.Tests/NServiceBus.Unity.Tests.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity.Container" Version="5.10.1" />
+    <PackageReference Include="Unity.Container" Version="5.11.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />

--- a/src/NServiceBus.Unity.Tests/When_using_existing_container.cs
+++ b/src/NServiceBus.Unity.Tests/When_using_existing_container.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
     using global::Unity;
     using NUnit.Framework;
+    using ObjectBuilder;
 
     [TestFixture]
     public class When_using_existing_container
@@ -144,6 +145,26 @@
 
             Assert.IsNotNull(result.Dependency);
         }
+
+        [Test]
+        public void Resolving_factories_should_work()
+        {
+            var unity = new UnityContainer();
+
+            var container = new UnityObjectBuilder(unity);
+            var builderType = typeof(Endpoint).Assembly.GetTypes().FirstOrDefault(t => t.Name?.Equals("CommonObjectBuilder") == true);
+            var builder = (IConfigureComponents)Activator.CreateInstance(builderType, container);
+
+            builder.ConfigureComponent(b =>
+            {
+                return new NamedService1();
+            }, DependencyLifecycle.SingleInstance);
+
+            var result = ((IBuilder)builder).Build<NamedService1>();
+
+            Assert.NotNull(result);
+        }
+
 
         class AbstractClass
         {

--- a/src/NServiceBus.Unity/NServiceBus.Unity.csproj
+++ b/src/NServiceBus.Unity/NServiceBus.Unity.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity.Container" Version="[5.9.7, 6.0.0)" />
+    <PackageReference Include="Unity.Container" Version="5.11.1" />
     <PackageReference Include="NServiceBus" Version="[7.0.1, 8.0.0)" />
     <PackageReference Include="Fody" Version="3.3.5" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.6.5" PrivateAssets="All" />


### PR DESCRIPTION
This contains upgrade to the next minor of Unity and a test showing how it will break. The NRE will cascade all the way when initializing an NSB endpoint so it is a showstopper for someone upgrading to the latest of Unity v5. 